### PR TITLE
added metrics for vulnerabilities on a workload level

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ go run main.go
 ```
 The exporter will start collecting security metrics from the Kubernetes cluster and exposing them for Prometheus to scrape.
 
+If you also want to collect metrics on a workload level you need to set an environment variable `ENABLE_WORKLOAD_METRICS=true`. Keep in mind that this will increase the number of metrics exposed by the exporter.
+
 6. Accessing Metrics:
 
 To access the exported metrics directly from the exporter, open your web browser and go to: `http://localhost:8080/metrics`

--- a/api/api.go
+++ b/api/api.go
@@ -9,6 +9,7 @@ import (
 	spdxclient "github.com/kubescape/storage/pkg/generated/clientset/versioned"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/pager"
 )
 
@@ -31,6 +32,10 @@ func NewStorageClient() *StorageClientImpl {
 	return &StorageClientImpl{
 		clientset: clientset,
 	}
+}
+
+func (sc *StorageClientImpl) WatchVulnerabilityManifestSummaries() (watch.Interface, error) {
+	return sc.clientset.SpdxV1beta1().VulnerabilityManifestSummaries("").Watch(context.Background(), metav1.ListOptions{})
 }
 
 func (sc *StorageClientImpl) GetVulnerabilityManifestSummaries() (*v1beta1.VulnerabilityManifestSummaryList, error) {
@@ -59,6 +64,10 @@ func (sc *StorageClientImpl) GetVulnerabilitySummaries() (*v1beta1.Vulnerability
 
 	return vulnsummary, nil
 
+}
+
+func (sc *StorageClientImpl) WatchWorkloadConfigurationScanSummaries() (watch.Interface, error) {
+	return sc.clientset.SpdxV1beta1().WorkloadConfigurationScanSummaries("").Watch(context.Background(), metav1.ListOptions{})
 }
 
 func (sc *StorageClientImpl) GetWorkloadConfigurationScanSummaries() (*v1beta1.WorkloadConfigurationScanSummaryList, error) {

--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-
 	"github.com/kubescape/go-logger"
 	"github.com/kubescape/go-logger/helpers"
 	"github.com/kubescape/k8s-interface/k8sinterface"
@@ -33,6 +32,26 @@ func NewStorageClient() *StorageClientImpl {
 	}
 }
 
+func (sc *StorageClientImpl) GetVulnerabilityManifestSummaries() (*v1beta1.VulnerabilityManifestSummaryList, error) {
+	vulnerabilityManifestSummaries, err := sc.clientset.SpdxV1beta1().VulnerabilityManifestSummaries("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO check if there's a better way instead of looping through all the items which is not efficient (time and memory)
+	// enrich the summary list with the full object as the list only contains the metadata
+	var list v1beta1.VulnerabilityManifestSummaryList
+	for _, vuln := range vulnerabilityManifestSummaries.Items {
+		item, err := sc.clientset.SpdxV1beta1().VulnerabilityManifestSummaries(vuln.Namespace).Get(context.TODO(), vuln.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		list.Items = append(list.Items, *item)
+	}
+
+	return &list, nil
+}
+
 func (sc *StorageClientImpl) GetVulnerabilitySummaries() (*v1beta1.VulnerabilitySummaryList, error) {
 	vulnsummary, err := sc.clientset.SpdxV1beta1().VulnerabilitySummaries("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
@@ -41,6 +60,26 @@ func (sc *StorageClientImpl) GetVulnerabilitySummaries() (*v1beta1.Vulnerability
 
 	return vulnsummary, nil
 
+}
+
+func (sc *StorageClientImpl) GetWorkloadConfigurationScanSummaries() (*v1beta1.WorkloadConfigurationScanSummaryList, error) {
+	workloadConfigurationScanSummaries, err := sc.clientset.SpdxV1beta1().WorkloadConfigurationScanSummaries("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO check if there's a better way instead of looping through all the items which is not efficient (time and memory)
+	// enrich the summary list with the full object as the list only contains the metadata
+	var list v1beta1.WorkloadConfigurationScanSummaryList
+	for _, scan := range workloadConfigurationScanSummaries.Items {
+		item, err := sc.clientset.SpdxV1beta1().WorkloadConfigurationScanSummaries(scan.Namespace).Get(context.TODO(), scan.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		list.Items = append(list.Items, *item)
+	}
+
+	return &list, nil
 }
 
 func (sc *StorageClientImpl) GetConfigScanSummaries() (*v1beta1.ConfigurationScanSummaryList, error) {

--- a/api/api.go
+++ b/api/api.go
@@ -76,8 +76,8 @@ func (sc *StorageClientImpl) GetWorkloadConfigurationScanSummaries() (*v1beta1.W
 		return sc.clientset.SpdxV1beta1().WorkloadConfigurationScanSummaries("").List(ctx, opts)
 	}).EachListItem(context.TODO(), metav1.ListOptions{}, func(obj runtime.Object) error {
 		// enrich the summary list with the full object as the list only contains the metadata
-		scan := obj.(*v1beta1.WorkloadConfigurationScanSummary)
-		item, err := sc.clientset.SpdxV1beta1().WorkloadConfigurationScanSummaries(scan.Namespace).Get(context.TODO(), scan.Name, metav1.GetOptions{})
+		summary := obj.(*v1beta1.WorkloadConfigurationScanSummary)
+		item, err := sc.clientset.SpdxV1beta1().WorkloadConfigurationScanSummaries(summary.Namespace).Get(context.TODO(), summary.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -46,28 +46,32 @@ func main() {
 func watchWorkloadVulnScanSummaries(storageClient *api.StorageClientImpl) {
 	watcher, _ := storageClient.WatchVulnerabilityManifestSummaries()
 	for event := range watcher.ResultChan() {
-		if event.Type != watch.Added && event.Type != watch.Deleted && event.Type != watch.Modified {
-			continue
+		item := event.Object.(*v1beta1.VulnerabilityManifestSummary)
+		if event.Type == watch.Added || event.Type == watch.Modified {
+			metrics.ProcessVulnWorkloadMetrics(&v1beta1.VulnerabilityManifestSummaryList{
+				Items: []v1beta1.VulnerabilityManifestSummary{*item},
+			})
 		}
 
-		item := event.Object.(*v1beta1.VulnerabilityManifestSummary)
-		metrics.ProcessVulnWorkloadMetrics(&v1beta1.VulnerabilityManifestSummaryList{
-			Items: []v1beta1.VulnerabilityManifestSummary{*item},
-		})
+		if event.Type == watch.Deleted {
+			metrics.DeleteVulnWorkloadMetric(item)
+		}
 	}
 }
 
 func watchWorkloadConfigScanSummaries(storageClient *api.StorageClientImpl) {
 	watcher, _ := storageClient.WatchWorkloadConfigurationScanSummaries()
 	for event := range watcher.ResultChan() {
-		if event.Type != watch.Added && event.Type != watch.Deleted && event.Type != watch.Modified {
-			continue
+		item := event.Object.(*v1beta1.WorkloadConfigurationScanSummary)
+		if event.Type == watch.Added || event.Type == watch.Modified {
+			metrics.ProcessConfigscanWorkloadMetrics(&v1beta1.WorkloadConfigurationScanSummaryList{
+				Items: []v1beta1.WorkloadConfigurationScanSummary{*item},
+			})
 		}
 
-		item := event.Object.(*v1beta1.WorkloadConfigurationScanSummary)
-		metrics.ProcessConfigscanWorkloadMetrics(&v1beta1.WorkloadConfigurationScanSummaryList{
-			Items: []v1beta1.WorkloadConfigurationScanSummary{*item},
-		})
+		if event.Type == watch.Deleted {
+			metrics.DeleteConfigscanWorkloadMetric(item)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -27,10 +27,23 @@ func main() {
 		handleConfigScanSummaries(storageClient)
 		handleVulnScanSummaries(storageClient)
 
+		// TODO check if workload metrics should be enabled by default or if they should be enabled by an env variable
+		handleWorkloadConfigScanSummaries(storageClient)
+		handleWorkloadVulnScanSummaries(storageClient)
+
 		// FIXME: get interval from config/env
 		time.Sleep(120 * time.Second)
 	}
 
+}
+
+func handleWorkloadConfigScanSummaries(storageClient *api.StorageClientImpl) {
+	workloadConfigurationScanSummaries, err := storageClient.GetWorkloadConfigurationScanSummaries()
+	if err != nil {
+		logger.L().Warning("failed getting workload configuration scan summaries", helpers.Error(err))
+		return
+	}
+	metrics.ProcessConfigscanWorkloadMetrics(workloadConfigurationScanSummaries)
 }
 
 func handleConfigScanSummaries(storageClient *api.StorageClientImpl) {
@@ -42,7 +55,15 @@ func handleConfigScanSummaries(storageClient *api.StorageClientImpl) {
 
 	metrics.ProcessConfigscanClusterMetrics(configScanSummaries)
 	metrics.ProcessConfigscanNamespaceMetrics(configScanSummaries)
+}
 
+func handleWorkloadVulnScanSummaries(storageClient *api.StorageClientImpl) {
+	vulnerabilityManifestSummaries, err := storageClient.GetVulnerabilityManifestSummaries()
+	if err != nil {
+		logger.L().Warning("failed getting vulnerability manifest summaries", helpers.Error(err))
+		return
+	}
+	metrics.ProcessVulnWorkloadMetrics(vulnerabilityManifestSummaries)
 }
 
 func handleVulnScanSummaries(storageClient *api.StorageClientImpl) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/prometheus/client_golang/prometheus"
+	"os"
 	"strings"
 )
 
@@ -232,12 +233,23 @@ var (
 )
 
 func init() {
-	// TODO check if workload metrics should be enabled by default or if they should be enabled by an env variable
-	prometheus.MustRegister(workloadCritical)
-	prometheus.MustRegister(workloadHigh)
-	prometheus.MustRegister(workloadMedium)
-	prometheus.MustRegister(workloadLow)
-	prometheus.MustRegister(workloadUnknown)
+	if os.Getenv("ENABLE_WORKLOAD_METRICS") == "true" {
+		prometheus.MustRegister(workloadCritical)
+		prometheus.MustRegister(workloadHigh)
+		prometheus.MustRegister(workloadMedium)
+		prometheus.MustRegister(workloadLow)
+		prometheus.MustRegister(workloadUnknown)
+		prometheus.MustRegister(workloadVulnCritical)
+		prometheus.MustRegister(workloadVulnHigh)
+		prometheus.MustRegister(workloadVulnMedium)
+		prometheus.MustRegister(workloadVulnLow)
+		prometheus.MustRegister(workloadVulnUnknown)
+		prometheus.MustRegister(workloadVulnCriticalRelevant)
+		prometheus.MustRegister(workloadVulnHighRelevant)
+		prometheus.MustRegister(workloadVulnMediumRelevant)
+		prometheus.MustRegister(workloadVulnLowRelevant)
+		prometheus.MustRegister(workloadVulnUnknownRelevant)
+	}
 	prometheus.MustRegister(namespaceCritical)
 	prometheus.MustRegister(namespaceHigh)
 	prometheus.MustRegister(namespaceMedium)
@@ -248,12 +260,6 @@ func init() {
 	prometheus.MustRegister(clusterMedium)
 	prometheus.MustRegister(clusterLow)
 	prometheus.MustRegister(clusterUnknown)
-	// TODO check if workload metrics should be enabled by default or if they should be enabled by an env variable
-	prometheus.MustRegister(workloadVulnCritical)
-	prometheus.MustRegister(workloadVulnHigh)
-	prometheus.MustRegister(workloadVulnMedium)
-	prometheus.MustRegister(workloadVulnLow)
-	prometheus.MustRegister(workloadVulnUnknown)
 	prometheus.MustRegister(namespaceVulnCritical)
 	prometheus.MustRegister(namespaceVulnHigh)
 	prometheus.MustRegister(namespaceVulnMedium)
@@ -264,12 +270,6 @@ func init() {
 	prometheus.MustRegister(clusterVulnMedium)
 	prometheus.MustRegister(clusterVulnLow)
 	prometheus.MustRegister(clusterVulnUnknown)
-	// TODO check if workload metrics should be enabled by default or if they should be enabled by an env variable
-	prometheus.MustRegister(workloadVulnCriticalRelevant)
-	prometheus.MustRegister(workloadVulnHighRelevant)
-	prometheus.MustRegister(workloadVulnMediumRelevant)
-	prometheus.MustRegister(workloadVulnLowRelevant)
-	prometheus.MustRegister(workloadVulnUnknownRelevant)
 	prometheus.MustRegister(namespaceVulnCriticalRelevant)
 	prometheus.MustRegister(namespaceVulnHighRelevant)
 	prometheus.MustRegister(namespaceVulnMediumRelevant)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -3,9 +3,35 @@ package metrics
 import (
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/prometheus/client_golang/prometheus"
+	"strings"
 )
 
 var (
+	workloadCritical = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_controls_total_workload_critical",
+		Help: "Total number of critical vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadHigh = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_controls_total_workload_high",
+		Help: "Total number of high vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadMedium = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_controls_total_workload_medium",
+		Help: "Total number of medium vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadLow = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_controls_total_workload_low",
+		Help: "Total number of low vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadUnknown = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_controls_total_workload_unknown",
+		Help: "Total number of unknown vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
 	namespaceCritical = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_controls_total_namespace_critical",
 		Help: "Total number of critical vulnerabilities in the namespace",
@@ -55,6 +81,31 @@ var (
 		Help: "Total number of unknown vulnerabilities in the cluster",
 	})
 
+	workloadVulnCritical = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_vulnerabilities_total_workload_critical",
+		Help: "Total number of critical vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadVulnHigh = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_vulnerabilities_total_workload_high",
+		Help: "Total number of high vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadVulnMedium = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_vulnerabilities_total_workload_medium",
+		Help: "Total number of medium vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadVulnLow = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_vulnerabilities_total_workload_low",
+		Help: "Total number of low vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadVulnUnknown = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_vulnerabilities_total_workload_unknown",
+		Help: "Total number of unknown vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
 	namespaceVulnCritical = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_total_namespace_critical",
 		Help: "Total number of critical vulnerabilities in the namespace",
@@ -103,6 +154,31 @@ var (
 		Name: "kubescape_vulnerabilities_total_cluster_unknown",
 		Help: "Total number of unknown vulnerabilities in the cluster",
 	})
+
+	workloadVulnCriticalRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_vulnerabilities_relevant_workload_critical",
+		Help: "Number of relevant critical vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadVulnHighRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_vulnerabilities_relevant_workload_high",
+		Help: "Number of relevant high vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadVulnMediumRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_vulnerabilities_relevant_workload_medium",
+		Help: "Number of relevant medium vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadVulnLowRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_vulnerabilities_relevant_workload_low",
+		Help: "Number of relevant low vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
+
+	workloadVulnUnknownRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "kubescape_vulnerabilities_relevant_workload_unknown",
+		Help: "Number of relevant unknown vulnerabilities in the workload",
+	}, []string{"namespace", "workload", "workload_kind"})
 
 	namespaceVulnCriticalRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_relevant_namespace_critical",
@@ -156,6 +232,12 @@ var (
 )
 
 func init() {
+	// TODO check if workload metrics should be enabled by default or if they should be enabled by an env variable
+	prometheus.MustRegister(workloadCritical)
+	prometheus.MustRegister(workloadHigh)
+	prometheus.MustRegister(workloadMedium)
+	prometheus.MustRegister(workloadLow)
+	prometheus.MustRegister(workloadUnknown)
 	prometheus.MustRegister(namespaceCritical)
 	prometheus.MustRegister(namespaceHigh)
 	prometheus.MustRegister(namespaceMedium)
@@ -166,6 +248,12 @@ func init() {
 	prometheus.MustRegister(clusterMedium)
 	prometheus.MustRegister(clusterLow)
 	prometheus.MustRegister(clusterUnknown)
+	// TODO check if workload metrics should be enabled by default or if they should be enabled by an env variable
+	prometheus.MustRegister(workloadVulnCritical)
+	prometheus.MustRegister(workloadVulnHigh)
+	prometheus.MustRegister(workloadVulnMedium)
+	prometheus.MustRegister(workloadVulnLow)
+	prometheus.MustRegister(workloadVulnUnknown)
 	prometheus.MustRegister(namespaceVulnCritical)
 	prometheus.MustRegister(namespaceVulnHigh)
 	prometheus.MustRegister(namespaceVulnMedium)
@@ -176,6 +264,12 @@ func init() {
 	prometheus.MustRegister(clusterVulnMedium)
 	prometheus.MustRegister(clusterVulnLow)
 	prometheus.MustRegister(clusterVulnUnknown)
+	// TODO check if workload metrics should be enabled by default or if they should be enabled by an env variable
+	prometheus.MustRegister(workloadVulnCriticalRelevant)
+	prometheus.MustRegister(workloadVulnHighRelevant)
+	prometheus.MustRegister(workloadVulnMediumRelevant)
+	prometheus.MustRegister(workloadVulnLowRelevant)
+	prometheus.MustRegister(workloadVulnUnknownRelevant)
 	prometheus.MustRegister(namespaceVulnCriticalRelevant)
 	prometheus.MustRegister(namespaceVulnHighRelevant)
 	prometheus.MustRegister(namespaceVulnMediumRelevant)
@@ -186,6 +280,19 @@ func init() {
 	prometheus.MustRegister(clusterVulnMediumRelevant)
 	prometheus.MustRegister(clusterVulnLowRelevant)
 	prometheus.MustRegister(clusterVulnUnknownRelevant)
+}
+
+func ProcessConfigscanWorkloadMetrics(summary *v1beta1.WorkloadConfigurationScanSummaryList) {
+	for _, item := range summary.Items {
+		namespace := item.ObjectMeta.Labels["kubescape.io/workload-namespace"]
+		workload := item.ObjectMeta.Labels["kubescape.io/workload-name"]
+		kind := strings.ToLower(item.ObjectMeta.Labels["kubescape.io/workload-kind"])
+		workloadCritical.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Critical))
+		workloadHigh.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.High))
+		workloadLow.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Low))
+		workloadMedium.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Medium))
+		workloadUnknown.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Unknown))
+	}
 }
 
 func ProcessConfigscanNamespaceMetrics(summary *v1beta1.ConfigurationScanSummaryList) {
@@ -216,6 +323,24 @@ func ProcessConfigscanClusterMetrics(summary *v1beta1.ConfigurationScanSummaryLi
 	clusterUnknown.Set(float64(totalUnknown))
 
 	return totalCritical, totalHigh, totalMedium, totalLow, totalUnknown
+}
+
+func ProcessVulnWorkloadMetrics(summary *v1beta1.VulnerabilityManifestSummaryList) {
+	for _, item := range summary.Items {
+		namespace := item.ObjectMeta.Labels["kubescape.io/workload-namespace"]
+		workload := item.ObjectMeta.Labels["kubescape.io/workload-name"]
+		kind := strings.ToLower(item.ObjectMeta.Labels["kubescape.io/workload-kind"])
+		workloadVulnCritical.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Critical.All))
+		workloadVulnHigh.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.High.All))
+		workloadVulnLow.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Low.All))
+		workloadVulnMedium.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Medium.All))
+		workloadVulnUnknown.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Unknown.All))
+		workloadVulnCriticalRelevant.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Critical.Relevant))
+		workloadVulnHighRelevant.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.High.Relevant))
+		workloadVulnLowRelevant.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Low.Relevant))
+		workloadVulnMediumRelevant.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Medium.Relevant))
+		workloadVulnUnknownRelevant.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Unknown.Relevant))
+	}
 }
 
 func ProcessVulnNamespaceMetrics(summary *v1beta1.VulnerabilitySummaryList) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -85,27 +85,27 @@ var (
 	workloadVulnCritical = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_total_workload_critical",
 		Help: "Total number of critical vulnerabilities in the workload",
-	}, []string{"namespace", "workload", "workload_kind"})
+	}, []string{"namespace", "workload", "workload_kind", "workload_container_name"})
 
 	workloadVulnHigh = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_total_workload_high",
 		Help: "Total number of high vulnerabilities in the workload",
-	}, []string{"namespace", "workload", "workload_kind"})
+	}, []string{"namespace", "workload", "workload_kind", "workload_container_name"})
 
 	workloadVulnMedium = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_total_workload_medium",
 		Help: "Total number of medium vulnerabilities in the workload",
-	}, []string{"namespace", "workload", "workload_kind"})
+	}, []string{"namespace", "workload", "workload_kind", "workload_container_name"})
 
 	workloadVulnLow = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_total_workload_low",
 		Help: "Total number of low vulnerabilities in the workload",
-	}, []string{"namespace", "workload", "workload_kind"})
+	}, []string{"namespace", "workload", "workload_kind", "workload_container_name"})
 
 	workloadVulnUnknown = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_total_workload_unknown",
 		Help: "Total number of unknown vulnerabilities in the workload",
-	}, []string{"namespace", "workload", "workload_kind"})
+	}, []string{"namespace", "workload", "workload_kind", "workload_container_name"})
 
 	namespaceVulnCritical = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_total_namespace_critical",
@@ -159,27 +159,27 @@ var (
 	workloadVulnCriticalRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_relevant_workload_critical",
 		Help: "Number of relevant critical vulnerabilities in the workload",
-	}, []string{"namespace", "workload", "workload_kind"})
+	}, []string{"namespace", "workload", "workload_kind", "workload_container_name"})
 
 	workloadVulnHighRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_relevant_workload_high",
 		Help: "Number of relevant high vulnerabilities in the workload",
-	}, []string{"namespace", "workload", "workload_kind"})
+	}, []string{"namespace", "workload", "workload_kind", "workload_container_name"})
 
 	workloadVulnMediumRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_relevant_workload_medium",
 		Help: "Number of relevant medium vulnerabilities in the workload",
-	}, []string{"namespace", "workload", "workload_kind"})
+	}, []string{"namespace", "workload", "workload_kind", "workload_container_name"})
 
 	workloadVulnLowRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_relevant_workload_low",
 		Help: "Number of relevant low vulnerabilities in the workload",
-	}, []string{"namespace", "workload", "workload_kind"})
+	}, []string{"namespace", "workload", "workload_kind", "workload_container_name"})
 
 	workloadVulnUnknownRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_relevant_workload_unknown",
 		Help: "Number of relevant unknown vulnerabilities in the workload",
-	}, []string{"namespace", "workload", "workload_kind"})
+	}, []string{"namespace", "workload", "workload_kind", "workload_container_name"})
 
 	namespaceVulnCriticalRelevant = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "kubescape_vulnerabilities_relevant_namespace_critical",
@@ -287,12 +287,25 @@ func ProcessConfigscanWorkloadMetrics(summary *v1beta1.WorkloadConfigurationScan
 		namespace := item.ObjectMeta.Labels["kubescape.io/workload-namespace"]
 		workload := item.ObjectMeta.Labels["kubescape.io/workload-name"]
 		kind := strings.ToLower(item.ObjectMeta.Labels["kubescape.io/workload-kind"])
+
 		workloadCritical.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Critical))
 		workloadHigh.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.High))
 		workloadLow.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Low))
 		workloadMedium.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Medium))
 		workloadUnknown.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Unknown))
 	}
+}
+
+func DeleteConfigscanWorkloadMetric(item *v1beta1.WorkloadConfigurationScanSummary) {
+	namespace := item.ObjectMeta.Labels["kubescape.io/workload-namespace"]
+	workload := item.ObjectMeta.Labels["kubescape.io/workload-name"]
+	kind := strings.ToLower(item.ObjectMeta.Labels["kubescape.io/workload-kind"])
+
+	workloadCritical.DeleteLabelValues(namespace, workload, kind)
+	workloadHigh.DeleteLabelValues(namespace, workload, kind)
+	workloadMedium.DeleteLabelValues(namespace, workload, kind)
+	workloadLow.DeleteLabelValues(namespace, workload, kind)
+	workloadUnknown.DeleteLabelValues(namespace, workload, kind)
 }
 
 func ProcessConfigscanNamespaceMetrics(summary *v1beta1.ConfigurationScanSummaryList) {
@@ -330,17 +343,37 @@ func ProcessVulnWorkloadMetrics(summary *v1beta1.VulnerabilityManifestSummaryLis
 		namespace := item.ObjectMeta.Labels["kubescape.io/workload-namespace"]
 		workload := item.ObjectMeta.Labels["kubescape.io/workload-name"]
 		kind := strings.ToLower(item.ObjectMeta.Labels["kubescape.io/workload-kind"])
-		workloadVulnCritical.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Critical.All))
-		workloadVulnHigh.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.High.All))
-		workloadVulnLow.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Low.All))
-		workloadVulnMedium.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Medium.All))
-		workloadVulnUnknown.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Unknown.All))
-		workloadVulnCriticalRelevant.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Critical.Relevant))
-		workloadVulnHighRelevant.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.High.Relevant))
-		workloadVulnLowRelevant.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Low.Relevant))
-		workloadVulnMediumRelevant.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Medium.Relevant))
-		workloadVulnUnknownRelevant.WithLabelValues(namespace, workload, kind).Set(float64(item.Spec.Severities.Unknown.Relevant))
+		containerName := strings.ToLower(item.ObjectMeta.Labels["kubescape.io/workload-container-name"])
+
+		workloadVulnCritical.WithLabelValues(namespace, workload, kind, containerName).Set(float64(item.Spec.Severities.Critical.All))
+		workloadVulnHigh.WithLabelValues(namespace, workload, kind, containerName).Set(float64(item.Spec.Severities.High.All))
+		workloadVulnMedium.WithLabelValues(namespace, workload, kind, containerName).Set(float64(item.Spec.Severities.Medium.All))
+		workloadVulnLow.WithLabelValues(namespace, workload, kind, containerName).Set(float64(item.Spec.Severities.Low.All))
+		workloadVulnUnknown.WithLabelValues(namespace, workload, kind, containerName).Set(float64(item.Spec.Severities.Unknown.All))
+		workloadVulnCriticalRelevant.WithLabelValues(namespace, workload, kind, containerName).Set(float64(item.Spec.Severities.Critical.Relevant))
+		workloadVulnHighRelevant.WithLabelValues(namespace, workload, kind, containerName).Set(float64(item.Spec.Severities.High.Relevant))
+		workloadVulnMediumRelevant.WithLabelValues(namespace, workload, kind, containerName).Set(float64(item.Spec.Severities.Medium.Relevant))
+		workloadVulnLowRelevant.WithLabelValues(namespace, workload, kind, containerName).Set(float64(item.Spec.Severities.Low.Relevant))
+		workloadVulnUnknownRelevant.WithLabelValues(namespace, workload, kind, containerName).Set(float64(item.Spec.Severities.Unknown.Relevant))
 	}
+}
+
+func DeleteVulnWorkloadMetric(item *v1beta1.VulnerabilityManifestSummary) {
+	namespace := item.ObjectMeta.Labels["kubescape.io/workload-namespace"]
+	workload := item.ObjectMeta.Labels["kubescape.io/workload-name"]
+	kind := strings.ToLower(item.ObjectMeta.Labels["kubescape.io/workload-kind"])
+	containerName := strings.ToLower(item.ObjectMeta.Labels["kubescape.io/workload-container-name"])
+
+	workloadVulnCritical.DeleteLabelValues(namespace, workload, kind, containerName)
+	workloadVulnHigh.DeleteLabelValues(namespace, workload, kind, containerName)
+	workloadVulnMedium.DeleteLabelValues(namespace, workload, kind, containerName)
+	workloadVulnLow.DeleteLabelValues(namespace, workload, kind, containerName)
+	workloadVulnUnknown.DeleteLabelValues(namespace, workload, kind, containerName)
+	workloadVulnCriticalRelevant.DeleteLabelValues(namespace, workload, kind, containerName)
+	workloadVulnHighRelevant.DeleteLabelValues(namespace, workload, kind, containerName)
+	workloadVulnMediumRelevant.DeleteLabelValues(namespace, workload, kind, containerName)
+	workloadVulnLowRelevant.DeleteLabelValues(namespace, workload, kind, containerName)
+	workloadVulnUnknownRelevant.DeleteLabelValues(namespace, workload, kind, containerName)
 }
 
 func ProcessVulnNamespaceMetrics(summary *v1beta1.VulnerabilitySummaryList) {

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,11 +1,133 @@
 package metrics
 
 import (
+	dto "github.com/prometheus/client_model/go"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestProcessVulnWorkloadMetrics(t *testing.T) {
+	vulnerabilityManifestSummaries := &v1beta1.VulnerabilityManifestSummaryList{
+		Items: []v1beta1.VulnerabilityManifestSummary{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"kubescape.io/workload-name":      "name1",
+						"kubescape.io/workload-kind":      "deployment",
+						"kubescape.io/workload-namespace": "namespace1",
+					},
+				},
+				Spec: v1beta1.VulnerabilityManifestSummarySpec{
+					Severities: v1beta1.SeveritySummary{
+						Critical: v1beta1.VulnerabilityCounters{
+							All:      3,
+							Relevant: 2,
+						},
+						High: v1beta1.VulnerabilityCounters{
+							All:      5,
+							Relevant: 4,
+						},
+						Medium: v1beta1.VulnerabilityCounters{
+							All:      10,
+							Relevant: 8,
+						},
+						Low: v1beta1.VulnerabilityCounters{
+							All:      20,
+							Relevant: 15,
+						},
+						Unknown: v1beta1.VulnerabilityCounters{
+							All:      7,
+							Relevant: 3,
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"kubescape.io/workload-name":      "name2",
+						"kubescape.io/workload-kind":      "deployment",
+						"kubescape.io/workload-namespace": "namespace2",
+					},
+				},
+				Spec: v1beta1.VulnerabilityManifestSummarySpec{
+					Severities: v1beta1.SeveritySummary{
+						Critical: v1beta1.VulnerabilityCounters{
+							All:      1,
+							Relevant: 15,
+						},
+						High: v1beta1.VulnerabilityCounters{
+							All:      9,
+							Relevant: 4,
+						},
+						Medium: v1beta1.VulnerabilityCounters{
+							All:      3,
+							Relevant: 5,
+						},
+						Low: v1beta1.VulnerabilityCounters{
+							All:      7,
+							Relevant: 3,
+						},
+						Unknown: v1beta1.VulnerabilityCounters{
+							All:      2,
+							Relevant: 5,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ProcessVulnWorkloadMetrics(vulnerabilityManifestSummaries)
+
+	allCritical := &dto.Metric{}
+	allHigh := &dto.Metric{}
+	allMedium := &dto.Metric{}
+	allLow := &dto.Metric{}
+	allUnknown := &dto.Metric{}
+	relevantCritical := &dto.Metric{}
+	relevantHigh := &dto.Metric{}
+	relevantMedium := &dto.Metric{}
+	relevantLow := &dto.Metric{}
+	relevantUnknown := &dto.Metric{}
+
+	ggeWorkloadVulnCritical, _ := workloadVulnCritical.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+	ggeWorkloadVulnHigh, _ := workloadVulnHigh.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+	ggeWorkloadVulnMedium, _ := workloadVulnMedium.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+	ggeWorkloadVulnLow, _ := workloadVulnLow.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+	ggeWorkloadVulnUnknown, _ := workloadVulnUnknown.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+
+	ggeWorkloadVulnCriticalRelevant, _ := workloadVulnCriticalRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+	ggeWorkloadVulnHighRelevant, _ := workloadVulnHighRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+	ggeWorkloadVulnMediumRelevant, _ := workloadVulnMediumRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+	ggeWorkloadVulnLowRelevant, _ := workloadVulnLowRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+	ggeWorkloadVulnUnknownRelevant, _ := workloadVulnUnknownRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+
+	_ = ggeWorkloadVulnCritical.Write(allCritical)
+	_ = ggeWorkloadVulnHigh.Write(allHigh)
+	_ = ggeWorkloadVulnMedium.Write(allMedium)
+	_ = ggeWorkloadVulnLow.Write(allLow)
+	_ = ggeWorkloadVulnUnknown.Write(allUnknown)
+	_ = ggeWorkloadVulnCriticalRelevant.Write(relevantCritical)
+	_ = ggeWorkloadVulnHighRelevant.Write(relevantHigh)
+	_ = ggeWorkloadVulnMediumRelevant.Write(relevantMedium)
+	_ = ggeWorkloadVulnLowRelevant.Write(relevantLow)
+	_ = ggeWorkloadVulnUnknownRelevant.Write(relevantUnknown)
+
+	assert.Equal(t, float64(3), allCritical.Gauge.GetValue(), "Expected allCritical to be 3")
+	assert.Equal(t, float64(5), allHigh.Gauge.GetValue(), "Expected allHigh to be 5")
+	assert.Equal(t, float64(10), allMedium.Gauge.GetValue(), "Expected allMedium to be 10")
+	assert.Equal(t, float64(20), allLow.Gauge.GetValue(), "Expected allLow to be 20")
+	assert.Equal(t, float64(7), allUnknown.Gauge.GetValue(), "Expected allUnknown to be 7")
+	assert.Equal(t, float64(2), relevantCritical.Gauge.GetValue(), "Expected relevantCritical to be 2")
+	assert.Equal(t, float64(4), relevantHigh.Gauge.GetValue(), "Expected relevantHigh to be 4")
+	assert.Equal(t, float64(8), relevantMedium.Gauge.GetValue(), "Expected relevantMedium to be 8")
+	assert.Equal(t, float64(15), relevantLow.Gauge.GetValue(), "Expected relevantLow to be 15")
+	assert.Equal(t, float64(3), relevantUnknown.Gauge.GetValue(), "Expected relevantUnknown to be 3")
+}
 
 func TestProcessVulnClusterMetrics(t *testing.T) {
 	// Create a fake VulnerabilitySummaryList
@@ -79,6 +201,57 @@ func TestProcessVulnClusterMetrics(t *testing.T) {
 	assert.Equal(t, 18, relevantLow, "Expected relevantLow to be 18")
 	assert.Equal(t, 8, relevantUnknown, "Expected relevantUnknown to be 8")
 
+}
+
+func TestProcessConfigscanWorkloadMetrics(t *testing.T) {
+	workloadConfigurationScanSummaries := &v1beta1.WorkloadConfigurationScanSummaryList{
+		Items: []v1beta1.WorkloadConfigurationScanSummary{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"kubescape.io/workload-name":      "name1",
+						"kubescape.io/workload-kind":      "ServiceAccount",
+						"kubescape.io/workload-namespace": "namespace1",
+					},
+				},
+				Spec: v1beta1.WorkloadConfigurationScanSummarySpec{
+					Severities: v1beta1.WorkloadConfigurationScanSeveritiesSummary{
+						Critical: 3,
+						High:     5,
+						Medium:   10,
+						Low:      20,
+						Unknown:  7,
+					},
+				},
+			},
+		},
+	}
+
+	ProcessConfigscanWorkloadMetrics(workloadConfigurationScanSummaries)
+
+	critical := &dto.Metric{}
+	high := &dto.Metric{}
+	medium := &dto.Metric{}
+	low := &dto.Metric{}
+	unknown := &dto.Metric{}
+
+	ggeWorkloadCritical, _ := workloadCritical.GetMetricWithLabelValues("namespace1", "name1", "serviceaccount")
+	ggeWorkloadHigh, _ := workloadHigh.GetMetricWithLabelValues("namespace1", "name1", "serviceaccount")
+	ggeWorkloadMedium, _ := workloadMedium.GetMetricWithLabelValues("namespace1", "name1", "serviceaccount")
+	ggeWorkloadLow, _ := workloadLow.GetMetricWithLabelValues("namespace1", "name1", "serviceaccount")
+	ggeWorkloadUnknown, _ := workloadUnknown.GetMetricWithLabelValues("namespace1", "name1", "serviceaccount")
+
+	_ = ggeWorkloadCritical.Write(critical)
+	_ = ggeWorkloadHigh.Write(high)
+	_ = ggeWorkloadMedium.Write(medium)
+	_ = ggeWorkloadLow.Write(low)
+	_ = ggeWorkloadUnknown.Write(unknown)
+
+	assert.Equal(t, float64(3), critical.Gauge.GetValue(), "Expected allCritical to be 3")
+	assert.Equal(t, float64(5), high.Gauge.GetValue(), "Expected allHigh to be 5")
+	assert.Equal(t, float64(10), medium.Gauge.GetValue(), "Expected allMedium to be 10")
+	assert.Equal(t, float64(20), low.Gauge.GetValue(), "Expected allLow to be 20")
+	assert.Equal(t, float64(7), unknown.Gauge.GetValue(), "Expected allUnknown to be 7")
 }
 
 func TestProcessConfigscanClusterMetrics(t *testing.T) {

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -15,9 +15,10 @@ func TestProcessVulnWorkloadMetrics(t *testing.T) {
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"kubescape.io/workload-name":      "name1",
-						"kubescape.io/workload-kind":      "deployment",
-						"kubescape.io/workload-namespace": "namespace1",
+						"kubescape.io/workload-name":           "name1",
+						"kubescape.io/workload-kind":           "deployment",
+						"kubescape.io/workload-namespace":      "namespace1",
+						"kubescape.io/workload-container-name": "container1",
 					},
 				},
 				Spec: v1beta1.VulnerabilityManifestSummarySpec{
@@ -48,9 +49,10 @@ func TestProcessVulnWorkloadMetrics(t *testing.T) {
 			{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"kubescape.io/workload-name":      "name2",
-						"kubescape.io/workload-kind":      "deployment",
-						"kubescape.io/workload-namespace": "namespace2",
+						"kubescape.io/workload-name":           "name2",
+						"kubescape.io/workload-kind":           "deployment",
+						"kubescape.io/workload-namespace":      "namespace2",
+						"kubescape.io/workload-container-name": "container2",
 					},
 				},
 				Spec: v1beta1.VulnerabilityManifestSummarySpec{
@@ -94,17 +96,17 @@ func TestProcessVulnWorkloadMetrics(t *testing.T) {
 	relevantLow := &dto.Metric{}
 	relevantUnknown := &dto.Metric{}
 
-	ggeWorkloadVulnCritical, _ := workloadVulnCritical.GetMetricWithLabelValues("namespace1", "name1", "deployment")
-	ggeWorkloadVulnHigh, _ := workloadVulnHigh.GetMetricWithLabelValues("namespace1", "name1", "deployment")
-	ggeWorkloadVulnMedium, _ := workloadVulnMedium.GetMetricWithLabelValues("namespace1", "name1", "deployment")
-	ggeWorkloadVulnLow, _ := workloadVulnLow.GetMetricWithLabelValues("namespace1", "name1", "deployment")
-	ggeWorkloadVulnUnknown, _ := workloadVulnUnknown.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+	ggeWorkloadVulnCritical, _ := workloadVulnCritical.GetMetricWithLabelValues("namespace1", "name1", "deployment", "container1")
+	ggeWorkloadVulnHigh, _ := workloadVulnHigh.GetMetricWithLabelValues("namespace1", "name1", "deployment", "container1")
+	ggeWorkloadVulnMedium, _ := workloadVulnMedium.GetMetricWithLabelValues("namespace1", "name1", "deployment", "container1")
+	ggeWorkloadVulnLow, _ := workloadVulnLow.GetMetricWithLabelValues("namespace1", "name1", "deployment", "container1")
+	ggeWorkloadVulnUnknown, _ := workloadVulnUnknown.GetMetricWithLabelValues("namespace1", "name1", "deployment", "container1")
 
-	ggeWorkloadVulnCriticalRelevant, _ := workloadVulnCriticalRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment")
-	ggeWorkloadVulnHighRelevant, _ := workloadVulnHighRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment")
-	ggeWorkloadVulnMediumRelevant, _ := workloadVulnMediumRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment")
-	ggeWorkloadVulnLowRelevant, _ := workloadVulnLowRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment")
-	ggeWorkloadVulnUnknownRelevant, _ := workloadVulnUnknownRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment")
+	ggeWorkloadVulnCriticalRelevant, _ := workloadVulnCriticalRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment", "container1")
+	ggeWorkloadVulnHighRelevant, _ := workloadVulnHighRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment", "container1")
+	ggeWorkloadVulnMediumRelevant, _ := workloadVulnMediumRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment", "container1")
+	ggeWorkloadVulnLowRelevant, _ := workloadVulnLowRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment", "container1")
+	ggeWorkloadVulnUnknownRelevant, _ := workloadVulnUnknownRelevant.GetMetricWithLabelValues("namespace1", "name1", "deployment", "container1")
 
 	_ = ggeWorkloadVulnCritical.Write(allCritical)
 	_ = ggeWorkloadVulnHigh.Write(allHigh)


### PR DESCRIPTION
## Overview
Currently the Prometheus Exporter only provides metrics on a cluster and namespace level. We find it useful to also have an overview on a workload level which gives the possibility to know which exact Deployment has the most vulnerabilities or define custom alerts.

According to the existing metrics name pattern a new suffix is introduced for Vulnerabilities and ConfigurationScans like:

* `kubescape_controls_total_workload_<severity>`
* `kubescape_vulnerabilities_total_workload_<severity>`
* `kubescape_vulnerabilities_relevant_workload_<severity>`

## Additional Information

Initial discussion started here: 
https://cloud-native.slack.com/archives/C04GY6H082K/p1733500846063089

## How to Test

* run tests
* start Prometheus Exporter and open http://localhost:8080/metrics


## Examples/Screenshots

This is how the metrics are exported via `/metrics` endpoint. Note the value is a dummy.

```
kubescape_controls_total_workload_medium{namespace="monitoring",workload="promtail",workload_kind="serviceaccount"} 1
kubescape_vulnerabilities_total_workload_critical{namespace="monitoring",workload="promtail",workload_kind="daemonset"} 2
kubescape_vulnerabilities_relevant_workload_medium{namespace="monitoring",workload="promtail",workload_kind="daemonset"} 3
```

<!-- 
## Related issues/PRs:

Here you add related issues and PRs.
If this resolved an issue, write "Resolved #<issue number>

e.g. If this PR resolves issues 1 and 2, it should look as follows:
* Resolved #1
* Resolved #2
-->

<!--
## Checklist before requesting a review

put an [x] in the box to get it checked 

- [ ] My code follows the style guidelines of this project
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] New and existing unit tests pass locally with my changes

**Please open the PR against the `dev` branch (Unless the PR contains only documentation changes)**

-->
 
