### PR TITLE
feat: add attestations: write permission for image provenance attestation

### DIFF
--- a/.github/workflows/pr-merged.yaml
+++ b/.github/workflows/pr-merged.yaml
@@ -37,6 +37,7 @@ jobs:
       packages: write
       contents: write
       pull-requests: read
+      attestations: write  # required by actions/attest-build-provenance in the shared workflow
     uses: kubescape/workflows/.github/workflows/incluster-comp-pr-merged.yaml@main
     with:
       IMAGE_NAME: quay.io/${{ github.repository_owner }}/prometheus-exporter


### PR DESCRIPTION
## Overview

Adds `attestations: write` to the `pr-merged` job permissions so the `actions/attest-build-provenance` step added to the shared `incluster-comp-pr-merged.yaml` workflow in kubescape/workflows can push attestations to the GitHub attestations API. Without this the attest step fails with a 403 on release runs.

## Additional Information

This is part of a series of PRs adding SLSA provenance attestation across kubescape repos, tracked in kubescape/kubescape#1033. Requires kubescape/workflows#89 to be merged first.

## Related issues/PRs

* Part of kubescape/kubescape#1033

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes
