### PR TITLE
fix(api): follow continuation token when listing summaries (kubescape/storage#337)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -34,6 +34,56 @@ func NewStorageClient() *StorageClientImpl {
 	}
 }
 
+// pagedList is satisfied by the *...List pointer types generated for the
+// softwarecomposition API. The continue accessors are promoted from the
+// embedded metav1.ListMeta.
+type pagedList[T any] interface {
+	*T
+	GetContinue() string
+	SetContinue(string)
+}
+
+// listAllPages lists every page of a resource, following the continuation token
+// the storage backend returns, and concatenates the items into a single list.
+//
+// The storage backend (kubescape/storage) applies a default page size of 500
+// when a client lists without an explicit limit and returns a continue token
+// for the remaining objects. A consumer that ignores that token silently sees
+// only the first 500 objects, which produces wrong cluster-wide and
+// per-namespace metrics on larger clusters (kubescape/storage#337). Following
+// the token guarantees the aggregation covers every object.
+//
+// ResourceVersionFullSpec is preserved across pages so every page carries the
+// full object spec rather than metadata only; it is set on ResourceVersion
+// (not ResourceVersionMatch), which is the only field allowed alongside a
+// continue token.
+func listAllPages[T any, PT pagedList[T]](
+	list func(opts metav1.ListOptions) (PT, error),
+	appendItems func(dst, src PT),
+) (PT, error) {
+	opts := metav1.ListOptions{ResourceVersion: softwarecomposition.ResourceVersionFullSpec}
+	var all PT
+	for {
+		page, err := list(opts)
+		if err != nil {
+			return nil, err
+		}
+		if all == nil {
+			all = page
+		} else {
+			appendItems(all, page)
+		}
+		token := page.GetContinue()
+		if token == "" {
+			// The accumulated list is complete; drop the first page's token so
+			// callers don't mistake it for a truncated result.
+			all.SetContinue("")
+			return all, nil
+		}
+		opts.Continue = token
+	}
+}
+
 func (sc *StorageClientImpl) WatchVulnerabilityManifestSummaries() (watch.Interface, error) {
 	// we need to pass the fullSpec resource version to get the full spec in Watch
 	return sc.clientset.SpdxV1beta1().VulnerabilityManifestSummaries("").Watch(context.Background(), metav1.ListOptions{ResourceVersion: softwarecomposition.ResourceVersionFullSpec})
@@ -41,12 +91,26 @@ func (sc *StorageClientImpl) WatchVulnerabilityManifestSummaries() (watch.Interf
 
 func (sc *StorageClientImpl) GetVulnerabilityManifestSummaries() (*v1beta1.VulnerabilityManifestSummaryList, error) {
 	// we need to pass the fullSpec resource version to get the full spec in GetList
-	return sc.clientset.SpdxV1beta1().VulnerabilityManifestSummaries("").List(context.Background(), metav1.ListOptions{ResourceVersion: softwarecomposition.ResourceVersionFullSpec})
+	return listAllPages(
+		func(opts metav1.ListOptions) (*v1beta1.VulnerabilityManifestSummaryList, error) {
+			return sc.clientset.SpdxV1beta1().VulnerabilityManifestSummaries("").List(context.Background(), opts)
+		},
+		func(dst, src *v1beta1.VulnerabilityManifestSummaryList) {
+			dst.Items = append(dst.Items, src.Items...)
+		},
+	)
 }
 
 func (sc *StorageClientImpl) GetVulnerabilitySummaries() (*v1beta1.VulnerabilitySummaryList, error) {
 	// VulnerabilitySummaries is a virtual resource, it has to be enabled in the storage
-	return sc.clientset.SpdxV1beta1().VulnerabilitySummaries("").List(context.Background(), metav1.ListOptions{ResourceVersion: softwarecomposition.ResourceVersionFullSpec})
+	return listAllPages(
+		func(opts metav1.ListOptions) (*v1beta1.VulnerabilitySummaryList, error) {
+			return sc.clientset.SpdxV1beta1().VulnerabilitySummaries("").List(context.Background(), opts)
+		},
+		func(dst, src *v1beta1.VulnerabilitySummaryList) {
+			dst.Items = append(dst.Items, src.Items...)
+		},
+	)
 }
 
 func (sc *StorageClientImpl) WatchWorkloadConfigurationScanSummaries() (watch.Interface, error) {
@@ -56,10 +120,24 @@ func (sc *StorageClientImpl) WatchWorkloadConfigurationScanSummaries() (watch.In
 
 func (sc *StorageClientImpl) GetWorkloadConfigurationScanSummaries() (*v1beta1.WorkloadConfigurationScanSummaryList, error) {
 	// we need to pass the fullSpec resource version to get the full spec in GetList
-	return sc.clientset.SpdxV1beta1().WorkloadConfigurationScanSummaries("").List(context.Background(), metav1.ListOptions{ResourceVersion: softwarecomposition.ResourceVersionFullSpec})
+	return listAllPages(
+		func(opts metav1.ListOptions) (*v1beta1.WorkloadConfigurationScanSummaryList, error) {
+			return sc.clientset.SpdxV1beta1().WorkloadConfigurationScanSummaries("").List(context.Background(), opts)
+		},
+		func(dst, src *v1beta1.WorkloadConfigurationScanSummaryList) {
+			dst.Items = append(dst.Items, src.Items...)
+		},
+	)
 }
 
 func (sc *StorageClientImpl) GetConfigScanSummaries() (*v1beta1.ConfigurationScanSummaryList, error) {
 	// ConfigScanSummaries is a virtual resource, it has to be enabled in the storage
-	return sc.clientset.SpdxV1beta1().ConfigurationScanSummaries("").List(context.Background(), metav1.ListOptions{ResourceVersion: softwarecomposition.ResourceVersionFullSpec})
+	return listAllPages(
+		func(opts metav1.ListOptions) (*v1beta1.ConfigurationScanSummaryList, error) {
+			return sc.clientset.SpdxV1beta1().ConfigurationScanSummaries("").List(context.Background(), opts)
+		},
+		func(dst, src *v1beta1.ConfigurationScanSummaryList) {
+			dst.Items = append(dst.Items, src.Items...)
+		},
+	)
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,126 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition"
+	"github.com/kubescape/storage/pkg/apis/softwarecomposition/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func summaryList(continueToken string, names ...string) *v1beta1.VulnerabilityManifestSummaryList {
+	list := &v1beta1.VulnerabilityManifestSummaryList{}
+	list.Continue = continueToken
+	for _, n := range names {
+		list.Items = append(list.Items, v1beta1.VulnerabilityManifestSummary{
+			ObjectMeta: metav1.ObjectMeta{Name: n},
+		})
+	}
+	return list
+}
+
+func appendSummaries(dst, src *v1beta1.VulnerabilityManifestSummaryList) {
+	dst.Items = append(dst.Items, src.Items...)
+}
+
+func TestListAllPages_FollowsContinueToken(t *testing.T) {
+	// Three pages: the first two return a continue token, the last is partial.
+	pages := []*v1beta1.VulnerabilityManifestSummaryList{
+		summaryList("token-1", "a", "b"),
+		summaryList("token-2", "c", "d"),
+		summaryList("", "e"),
+	}
+	var seenContinue []string
+	call := 0
+
+	got, err := listAllPages(
+		func(opts metav1.ListOptions) (*v1beta1.VulnerabilityManifestSummaryList, error) {
+			// Every page must keep requesting the full spec.
+			if opts.ResourceVersion != softwarecomposition.ResourceVersionFullSpec {
+				t.Fatalf("page %d: ResourceVersion = %q, want %q", call, opts.ResourceVersion, softwarecomposition.ResourceVersionFullSpec)
+			}
+			seenContinue = append(seenContinue, opts.Continue)
+			page := pages[call]
+			call++
+			return page, nil
+		},
+		appendSummaries,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The continue token from each page must be threaded into the next request.
+	wantContinue := []string{"", "token-1", "token-2"}
+	if len(seenContinue) != len(wantContinue) {
+		t.Fatalf("made %d requests, want %d", len(seenContinue), len(wantContinue))
+	}
+	for i := range wantContinue {
+		if seenContinue[i] != wantContinue[i] {
+			t.Errorf("request %d Continue = %q, want %q", i, seenContinue[i], wantContinue[i])
+		}
+	}
+
+	// All items from every page must be aggregated.
+	var gotNames []string
+	for _, item := range got.Items {
+		gotNames = append(gotNames, item.Name)
+	}
+	wantNames := []string{"a", "b", "c", "d", "e"}
+	if len(gotNames) != len(wantNames) {
+		t.Fatalf("got %d items %v, want %d %v", len(gotNames), gotNames, len(wantNames), wantNames)
+	}
+	for i := range wantNames {
+		if gotNames[i] != wantNames[i] {
+			t.Errorf("item %d = %q, want %q", i, gotNames[i], wantNames[i])
+		}
+	}
+
+	// The accumulated list must not advertise a stale continue token.
+	if got.Continue != "" {
+		t.Errorf("aggregated list Continue = %q, want empty", got.Continue)
+	}
+}
+
+func TestListAllPages_SinglePage(t *testing.T) {
+	call := 0
+	got, err := listAllPages(
+		func(opts metav1.ListOptions) (*v1beta1.VulnerabilityManifestSummaryList, error) {
+			call++
+			return summaryList("", "only"), nil
+		},
+		appendSummaries,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if call != 1 {
+		t.Errorf("made %d requests, want 1", call)
+	}
+	if len(got.Items) != 1 || got.Items[0].Name != "only" {
+		t.Errorf("got items %v, want [only]", got.Items)
+	}
+}
+
+func TestListAllPages_PropagatesError(t *testing.T) {
+	wantErr := errors.New("boom")
+	// First page succeeds, second page errors out.
+	call := 0
+	got, err := listAllPages(
+		func(opts metav1.ListOptions) (*v1beta1.VulnerabilityManifestSummaryList, error) {
+			call++
+			if call == 1 {
+				return summaryList("token-1", "a"), nil
+			}
+			return nil, wantErr
+		},
+		appendSummaries,
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if got != nil {
+		t.Errorf("got = %v, want nil on error", got)
+	}
+}


### PR DESCRIPTION
## Problem

The storage backend ([kubescape/storage](https://github.com/kubescape/storage)) applies a hard-coded default page size of **500** when a client lists objects without an explicit limit, and returns a `metadata.continue` token for the rest:

```go
// pkg/registry/file/storage.go
if opts.Predicate.Limit == 0 {
    opts.Predicate.Limit = 500
}
```

`api/api.go` lists summaries with `ResourceVersionFullSpec` but **never consumed that continue token**. On any cluster with more than 500 scanned objects (common in production), the exporter aggregated metrics from only the first page:

- whole namespaces beyond the first page **silently disappeared** from `kubescape_controls_total_*` / vulnerability metrics;
- per-namespace severity counters were wrong (e.g. a namespace reporting `high: 0` via LIST while a direct GET returned `high: 91`);
- no warning anywhere — dashboards looked healthy while being incorrect.

Reported in kubescape/storage#337.

## Fix

Add a generic `listAllPages` helper that follows the continuation token across pages, accumulating every object, and route all four `Get*` list methods through it.

- `ResourceVersionFullSpec` is preserved on **every** page request so each page still carries the full object spec. It is set via `ResourceVersion` (not `ResourceVersionMatch`), which is the only one allowed alongside a continue token — `ValidateListOptions` in apimachinery forbids `ResourceVersionMatch` + `Continue`, but not `ResourceVersion` + `Continue`.
- The two **virtual** resources (`VulnerabilitySummaries`, `ConfigurationScanSummaries`) ignore list options server-side and never return a continue token, so they resolve in a single iteration — unaffected.
- The aggregated list's continue token is cleared so downstream consumers don't mistake the merged result for a truncated page.

## Scope

`ConfigurationScanSummaryStorage.GetList` (in the storage repo) is the server-side aggregation and is **out of scope** for this PR — it is tracked separately in kubescape/storage#337.

## Tests

Added `api/api_test.go` covering:
- multi-page accumulation with correct continue-token threading and `ResourceVersionFullSpec` re-sent on every page;
- single-page (virtual-resource) behavior;
- error propagation.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

Fixes part of kubescape/storage#337.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and completeness of list operations by ensuring vulnerability manifests, vulnerability summaries, workload configuration scans, and configuration scans return all available results across all pages.

* **Tests**
  * Added comprehensive test coverage for multi-page list operations, including continuation token handling, item aggregation, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->